### PR TITLE
Only compile rustyline on Unix

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,12 +18,14 @@ name = "matzo-regenerate"
 test = true
 path = "tools/regenerate.rs"
 
+[target.'cfg(unix)'.dependencies]
+rustyline = "9.1"
+
 [dependencies]
 regex = "1.5.5"
 rand = "*"
 lalrpop-util = { version = "*", features = ["lexer"] }
 logos = "*"
-rustyline = "9.1"
 ansi_term = "*"
 string-interner = "*"
 anyhow = "*"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,6 +8,7 @@ pub mod errors;
 pub mod interp;
 pub mod lexer;
 pub mod rand;
+#[cfg(unix)]
 pub mod repl;
 pub mod value;
 


### PR DESCRIPTION
This makes rustyline dependent on target platform: this is necessary because rustyline includes file-system-specific stuff that won't compile for WASM.