### PR TITLE
Implement record update syntax

### DIFF
--- a/src/ast.rs
+++ b/src/ast.rs
@@ -64,6 +64,8 @@ pub enum Expr {
     Case(ExprRef, Vec<Case>),
     /// Accessing the field of a record
     Access(ExprRef, Name),
+    ///Updating records
+    With(ExprRef, Vec<Field>),
     /// An empty tree. (We can't write this, but we desugar into it
     /// sometimes)
     Nil,
@@ -435,6 +437,20 @@ impl ASTArena {
                 self.show_expr(&self[expr.item], f, depth + 2)?;
                 self.indent(f, depth)?;
                 writeln!(f, "{}", &self[field.item])
+            }
+
+            Expr::With(expr, fields) => {
+                writeln!(f, "With(")?;
+                self.indent(f, depth)?;
+                self.show_expr(&self[expr.item], f, depth + 2)?;
+                for e in fields {
+                    self.indent(f, depth + 2)?;
+                    writeln!(f, "{}:", &self[e.name.item])?;
+                    self.indent(f, depth + 2)?;
+                    self.show_expr(&self[e.expr], f, depth + 2)?;
+                }
+                self.indent(f, depth)?;
+                writeln!(f, ")")
             }
         }
     }

--- a/src/grammar.lalrpop
+++ b/src/grammar.lalrpop
@@ -32,6 +32,7 @@ extern {
         "in" => Token::In,
         "fix" => Token::Fix,
         "fn" => Token::Fn,
+        "with" => Token::With,
         "var" => Token::Var(<&'input str>),
         "atom" => Token::Atom(<&'input str>),
         "num" => Token::Num(<i64>),
@@ -139,6 +140,11 @@ pub Subbranch: ExprId = {
 pub Leaf: ExprId = {
     <Literal> => ast.add_expr(Expr::Lit(<>)),
     <Name> => ast.add_expr(Expr::Var(<>)),
+    <l:Located<Leaf>> "with" "{" <fields:(Field ",")*> <f:Field> ","? "}" => {
+      let mut fields = fields.into_iter().map(|(f, _)| f).collect::<Vec<Field>>();
+      fields.push(f);
+      ast.add_expr(Expr::With(l, fields))
+    },
     "<" <mut es:(<Located<Expr>> ",")*> <e:Located<Expr>> ">" => {
         if es.len() == 0 && e.item.nil() {
             ast.add_expr(Expr::Tup(Vec::new()))

--- a/src/interp.rs
+++ b/src/interp.rs
@@ -491,6 +491,24 @@ impl State {
                 };
                 self.hnf(thunk)
             }
+
+            Expr::With(expr, fields) => {
+                let mut record = if let Value::Record(rec) = self.eval(*expr, env)? {
+                    rec
+                } else {
+                    return Err(MatzoError::new(
+                        expr_ref.loc,
+                        "{} is not a record and cannot be updated with record update syntax"
+                            .to_string(),
+                    ));
+                };
+
+                for f in fields {
+                    record.insert(f.name.item, Thunk::Expr(f.expr, env.clone()));
+                }
+
+                Ok(Value::Record(record))
+            }
         }
     }
 

--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -120,6 +120,9 @@ pub enum Token<'a> {
     #[token("fn")]
     Fn,
 
+    #[token("with")]
+    With,
+
     #[regex(r"\p{Ll}(\pL|[0-9_/-])*")]
     Var(&'a str),
 
@@ -178,6 +181,7 @@ impl<'a> Token<'a> {
             Token::In => "`in`".to_string(),
             Token::Fix => "`fix`".to_string(),
             Token::Fn => "`fn`".to_string(),
+            Token::With => "`with`".to_string(),
 
             Token::Error => "error".to_string(),
         }


### PR DESCRIPTION
This allows for `expr where { key: expr, key: expr }` which produces a copy of `expr` where the keys have been replaced by the given expressions. (They are lazy, so e.g. `let x := {x: 0}; y := x with {x: 1|2} in { y.x y.x }` will non-deterministically produce `11`, `12`, `21`, and `22`.)