### PR TITLE
Normalize output and allow Unicode escapes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -561,6 +561,7 @@ dependencies = [
  "serde_yaml",
  "string-interner",
  "titlecase",
+ "unicode-normalization",
  "vergen",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,7 @@ serde = { version = "1.0", features = ["derive"] }
 clap = "2.33"
 serde_yaml = "0.8"
 dirs = "*"
+unicode-normalization = "*"
 
 [build-dependencies]
 vergen = "*"

--- a/src/interp.rs
+++ b/src/interp.rs
@@ -12,6 +12,7 @@ use std::collections::{BTreeMap, BTreeSet, HashMap};
 use std::fmt;
 use std::io;
 use std::rc::Rc;
+use unicode_normalization::UnicodeNormalization;
 
 /// A `Callback` here is what we use for builtin functions: they take
 /// the state and the env along with a (non-empty) list of
@@ -260,7 +261,9 @@ impl State {
             Stmt::Puts(expr) => {
                 let val = self.eval(*expr, &None)?;
                 let val = self.force(val)?;
-                writeln!(output, "{}", val.to_string(&self.ast.borrow())).unwrap();
+                let raw_str = val.to_string(&self.ast.borrow());
+                let nfc: String = raw_str.nfc().collect();
+                writeln!(output, "{}", nfc).unwrap();
             }
 
             // Look up the provided name, and if it's not already

--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -39,6 +39,14 @@ fn parse_escapes<'a>(src: &'a str) -> Option<String> {
                 Some('n') => buf.push('\n'),
                 Some('t') => buf.push('\t'),
                 Some('r') => buf.push('\r'),
+                Some('u') => {
+                    let a = as_hex(src.next()?)?;
+                    let b = as_hex(src.next()?)?;
+                    let c = as_hex(src.next()?)?;
+                    let d = as_hex(src.next()?)?;
+                    let res = a << 12 | b << 8 | c << 4 | d;
+                    buf.push(char::from_u32(res)?)
+                }
                 Some(c) => buf.push(c),
                 None => return None,
             }
@@ -47,6 +55,28 @@ fn parse_escapes<'a>(src: &'a str) -> Option<String> {
         }
     }
     Some(buf)
+}
+
+fn as_hex(chr: char) -> Option<u32> {
+    match chr {
+        '0' => Some(0),
+        '1' => Some(1),
+        '2' => Some(2),
+        '3' => Some(3),
+        '4' => Some(4),
+        '5' => Some(5),
+        '6' => Some(6),
+        '7' => Some(7),
+        '8' => Some(8),
+        '9' => Some(9),
+        'A' | 'a' => Some(10),
+        'B' | 'b' => Some(11),
+        'C' | 'c' => Some(12),
+        'D' | 'd' => Some(13),
+        'E' | 'e' => Some(14),
+        'F' | 'f' => Some(15),
+        _ => None,
+    }
 }
 
 fn parse_str<'a>(lex: &mut Lexer<'a, Token<'a>>) -> Option<String> {

--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -30,7 +30,14 @@ fn parse_num<'a>(lex: &mut Lexer<'a, Token<'a>>) -> Option<i64> {
     slice.parse().ok()
 }
 
-fn parse_escapes<'a>(src: &'a str) -> Option<String> {
+enum StringLitError {
+    UnexpectedEndAfterBackslash,
+    NotAHexDigit(char),
+    NotEnoughHexDigits,
+    NotAValidChar(u32),
+}
+
+fn parse_escapes<'a>(src: &'a str) -> Result<String, StringLitError> {
     let mut buf = String::new();
     let mut src = src.chars();
     while let Some(c) = src.next() {
@@ -40,51 +47,51 @@ fn parse_escapes<'a>(src: &'a str) -> Option<String> {
                 Some('t') => buf.push('\t'),
                 Some('r') => buf.push('\r'),
                 Some('u') => {
-                    let a = as_hex(src.next()?)?;
-                    let b = as_hex(src.next()?)?;
-                    let c = as_hex(src.next()?)?;
-                    let d = as_hex(src.next()?)?;
+                    let a = as_hex(src.next().ok_or(StringLitError::NotEnoughHexDigits)?)?;
+                    let b = as_hex(src.next().ok_or(StringLitError::NotEnoughHexDigits)?)?;
+                    let c = as_hex(src.next().ok_or(StringLitError::NotEnoughHexDigits)?)?;
+                    let d = as_hex(src.next().ok_or(StringLitError::NotEnoughHexDigits)?)?;
                     let res = a << 12 | b << 8 | c << 4 | d;
-                    buf.push(char::from_u32(res)?)
+                    buf.push(char::from_u32(res).ok_or(StringLitError::NotAValidChar(res))?);
                 }
                 Some(c) => buf.push(c),
-                None => return None,
+                None => return Err(StringLitError::UnexpectedEndAfterBackslash),
             }
         } else {
             buf.push(c);
         }
     }
-    Some(buf)
+    Ok(buf)
 }
 
-fn as_hex(chr: char) -> Option<u32> {
+fn as_hex(chr: char) -> Result<u32, StringLitError> {
     match chr {
-        '0' => Some(0),
-        '1' => Some(1),
-        '2' => Some(2),
-        '3' => Some(3),
-        '4' => Some(4),
-        '5' => Some(5),
-        '6' => Some(6),
-        '7' => Some(7),
-        '8' => Some(8),
-        '9' => Some(9),
-        'A' | 'a' => Some(10),
-        'B' | 'b' => Some(11),
-        'C' | 'c' => Some(12),
-        'D' | 'd' => Some(13),
-        'E' | 'e' => Some(14),
-        'F' | 'f' => Some(15),
-        _ => None,
+        '0' => Ok(0),
+        '1' => Ok(1),
+        '2' => Ok(2),
+        '3' => Ok(3),
+        '4' => Ok(4),
+        '5' => Ok(5),
+        '6' => Ok(6),
+        '7' => Ok(7),
+        '8' => Ok(8),
+        '9' => Ok(9),
+        'A' | 'a' => Ok(10),
+        'B' | 'b' => Ok(11),
+        'C' | 'c' => Ok(12),
+        'D' | 'd' => Ok(13),
+        'E' | 'e' => Ok(14),
+        'F' | 'f' => Ok(15),
+        _ => Err(StringLitError::NotAHexDigit(chr)),
     }
 }
 
-fn parse_str<'a>(lex: &mut Lexer<'a, Token<'a>>) -> Option<String> {
+fn parse_str<'a>(lex: &mut Lexer<'a, Token<'a>>) -> Result<String, StringLitError> {
     let s = lex.slice();
     parse_escapes(&s[1..s.len() - 1])
 }
 
-fn parse_fragment<'a>(lex: &mut Lexer<'a, FStringToken<'a>>) -> Option<String> {
+fn parse_fragment<'a>(lex: &mut Lexer<'a, FStringToken<'a>>) -> Result<String, StringLitError> {
     parse_escapes(lex.slice())
 }
 


### PR DESCRIPTION
This adds the ability to use four-character hex escapes (like `"\u0040"`) and also passes output through a normalization pass before printing it.